### PR TITLE
Return msg with the error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # User-specific stuff
 .idea/
+.vscode/
 
 # Logs
 logs

--- a/src/Read/ReadNode.js
+++ b/src/Read/ReadNode.js
@@ -49,9 +49,9 @@ FirestoreReadNode.prototype.main = function (msg, send, errorCb) {
   if (!rt) {
     referenceQuery.get()
       .then((snap) => snapHandler(snap))
-      .catch((err) => errorCb(err))
+      .catch((err) => errorCb(err, msg))
   } else {
-    this.snapListener = referenceQuery.onSnapshot((snap) => snapHandler(snap), (error) => errorCb(error))
+    this.snapListener = referenceQuery.onSnapshot((snap) => snapHandler(snap), (error) => errorCb(error, msg))
   }
 
   function snapHandler(snap) {

--- a/src/Write/WriteNode.js
+++ b/src/Write/WriteNode.js
@@ -59,7 +59,7 @@ FirestoreWriteNode.prototype.onInput = function (msg, send, errorCb) {
       referenceQuery = this.firestore.collection(col).doc(doc)[op](payload)
       break
     default:
-      return handleFailure(`Invalid operation given: ${op}`)
+      return handleFailure(`Invalid operation given: ${op}`, msg)
   }
 
   referenceQuery
@@ -67,10 +67,10 @@ FirestoreWriteNode.prototype.onInput = function (msg, send, errorCb) {
       msg.payload = result
       send(msg)
     })
-    .catch(handleFailure)
+    .catch((err) => handleFailure(err, msg));
 
-  function handleFailure(err) {
-    errorCb(err)
+  function handleFailure(err, msg) {
+    errorCb(err, msg);
   }
 }
 


### PR DESCRIPTION
When throwing an error, the msg object shoulb be [thrown as well](https://nodered.org/docs/creating-nodes/node-js#handling-errors).

This allow the use of `Catch` node in the flow.