### PR TITLE
add option to disable default snapshot handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Both the read & write nodes expose a ``firestore`` object adjacent to the
 ``payload`` object that contains the current app instance and a reference 
 to the firebase admin sdk, which allows you to extend the node to your liking.
  
-The Read node adds an additional ``query`` field that references a built query and only fi the ``disableHandler`` option is passed to it
+The Read node adds an additional ``query`` field that references a built query and only if the ``disableHandler`` option is passed to it
  
  ```
   {

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Configurations can be made within the node or on the ``msg.firestore`` property:
 - ``realtime``: [boolean] telling the node to listen for live updates or not (false by default)
 - ``group``: [boolean] fetch all documents under collections with the above supplied collection name (false by default)
 - ``query``: [array&lt;object&gt;] an array of objects defining query methods to apply to the read
+- ``disableHandler``: [boolean] disables the default snapshot handler, exposing a built query reference (false by default)
 
 Response data from the operation is output through the ``msg.payload`` property
 
@@ -188,17 +189,17 @@ becomes:
 
 ## Extensibility & further uses
 
-Both the read & write nodes expose a ``firebase`` object adjacent to the
+Both the read & write nodes expose a ``firestore`` object adjacent to the
 ``payload`` object that contains the current app instance and a reference 
 to the firebase admin sdk, which allows you to extend the node to your liking.
  
-The Read node adds an additional ``query`` field that references the last run query
+The Read node adds an additional ``query`` field that references a built query and only fi the ``disableHandler`` option is passed to it
  
  ```
   {
     "app": "...", => current firebase instance
     "admin": "...", => firebase admin sdk
-    "query": "..." => [Read node specific] last run query to the database
+    "query": "..." => [Read node specific] only if disableHandler option is passed to it
   }
  ```
 

--- a/README.md
+++ b/README.md
@@ -189,8 +189,7 @@ becomes:
 
 ## Extensibility & further uses
 
-Both the read & write nodes expose a ``firestore`` object adjacent to the
-``payload`` object that contains the current app instance and a reference 
+Both the read & write nodes expose a ``firebase`` object through the ``msg`` object that contains the current app instance and a reference 
 to the firebase admin sdk, which allows you to extend the node to your liking.
  
 The Read node adds an additional ``query`` field that references a built query and only if the ``disableHandler`` option is passed to it

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Configurations can be made within the node or on the ``msg.firestore`` property:
 - ``realtime``: [boolean] telling the node to listen for live updates or not (false by default)
 - ``group``: [boolean] fetch all documents under collections with the above supplied collection name (false by default)
 - ``query``: [array&lt;object&gt;] an array of objects defining query methods to apply to the read
-- ``disableHandler``: [boolean] disables the default snapshot handler, exposing a built query reference (false by default)
+- ``disableHandler``: [boolean] disables the default snapshot handler, returning a built query reference as the payload (false by default)
 
 Response data from the operation is output through the ``msg.payload`` property
 
@@ -198,7 +198,6 @@ The Read node adds an additional ``query`` field that references a built query a
   {
     "app": "...", => current firebase instance
     "admin": "...", => firebase admin sdk
-    "query": "..." => [Read node specific] only if disableHandler option is passed to it
   }
  ```
 

--- a/src/Read/Read.html
+++ b/src/Read/Read.html
@@ -58,6 +58,10 @@
           query <span class="property-type">array&lt;object&gt;</span>
           </dt>
         <dd>an array of objects defining query methods to apply to the read</dd>
+        <dt class="optional">
+          disableHandler <span class="property-type">boolean</span>
+          </dt>
+        <dd>disables the default snapshot handler, exposing a built query reference</dd>
     </dl>
     <p>
       The above inputs can also be set from within the

--- a/src/Read/Read.html
+++ b/src/Read/Read.html
@@ -61,7 +61,7 @@
         <dt class="optional">
           disableHandler <span class="property-type">boolean</span>
           </dt>
-        <dd>disables the default snapshot handler, exposing a built query reference</dd>
+        <dd>disables the default snapshot handler, exposing a built query reference as the payload</dd>
     </dl>
     <p>
       The above inputs can also be set from within the

--- a/src/Read/ReadNode.js
+++ b/src/Read/ReadNode.js
@@ -24,13 +24,14 @@ function FirestoreReadNode(config) {
 
 FirestoreReadNode.prototype.main = function (msg, send, errorCb) {
   const input = (msg.hasOwnProperty('firestore')) ? msg.firestore : {}
-  msg.firebase = {app: this.instance, admin: this.firebase}
+  msg.firestore = {app: this.instance, admin: this.firebase}
 
   const col = input.collection || this.collection
   const group = input.group || this.group
   const doc = input.document || this.document
   const rt = input.realtime || this.realtime
   const query = input.query || this.query
+  const disable = input.disableHandler || false
 
   if (doc && group) throw 'Cannot set document ref in a collection group query'
 
@@ -45,6 +46,11 @@ FirestoreReadNode.prototype.main = function (msg, send, errorCb) {
 
   // remove existing listener before registering another
   this.unsubscribeListener()
+
+  if (disable) {
+    msg.firestore.query = referenceQuery
+    return send(msg)
+  }
 
   if (!rt) {
     referenceQuery.get()
@@ -65,7 +71,6 @@ FirestoreReadNode.prototype.main = function (msg, send, errorCb) {
     } else {
       msg.payload = snap.data()
     }
-    msg.firebase.query = referenceQuery
     send(msg)
   }
 }

--- a/src/Read/ReadNode.js
+++ b/src/Read/ReadNode.js
@@ -24,7 +24,7 @@ function FirestoreReadNode(config) {
 
 FirestoreReadNode.prototype.main = function (msg, send, errorCb) {
   const input = (msg.hasOwnProperty('firestore')) ? msg.firestore : {}
-  msg.firestore = {app: this.instance, admin: this.firebase}
+  msg.firebase = {app: this.instance, admin: this.firebase}
 
   const col = input.collection || this.collection
   const group = input.group || this.group
@@ -48,7 +48,7 @@ FirestoreReadNode.prototype.main = function (msg, send, errorCb) {
   this.unsubscribeListener()
 
   if (disable) {
-    msg.firestore.query = referenceQuery
+    msg.payload = referenceQuery
     return send(msg)
   }
 

--- a/src/Write/WriteNode.js
+++ b/src/Write/WriteNode.js
@@ -35,7 +35,7 @@ FirestoreWriteNode.prototype.validateOperation = function ({operation: op, docum
 
 FirestoreWriteNode.prototype.onInput = function (msg, send, errorCb) {
   const input = (msg.hasOwnProperty('firestore')) ? msg['firestore'] : {}
-  msg.firebase = {app: this.instance, admin: this.firebase}
+  msg.firestore = {app: this.instance, admin: this.firebase}
 
   const col = input.collection || this.collection
   const doc = input.document || this.document

--- a/src/Write/WriteNode.js
+++ b/src/Write/WriteNode.js
@@ -35,7 +35,7 @@ FirestoreWriteNode.prototype.validateOperation = function ({operation: op, docum
 
 FirestoreWriteNode.prototype.onInput = function (msg, send, errorCb) {
   const input = (msg.hasOwnProperty('firestore')) ? msg['firestore'] : {}
-  msg.firestore = {app: this.instance, admin: this.firebase}
+  msg.firebase = {app: this.instance, admin: this.firebase}
 
   const col = input.collection || this.collection
   const doc = input.document || this.document


### PR DESCRIPTION
Add support for an input only option to disable the default snapshot handler and return a built query reference instead